### PR TITLE
Add HOCComponent case to 'toTree' function.

### DIFF
--- a/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
+++ b/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
@@ -48,6 +48,7 @@ const HostPortal = 4;
 const HostComponent = 5;
 const HostText = 6;
 const Mode = 11;
+const HOCComponent = 9;
 
 function nodeAndSiblingsArray(nodeWithSibling) {
   const array = [];
@@ -121,6 +122,8 @@ function toTree(vnode) {
   switch (node.tag) {
     case HostRoot: // 3
       return childrenToTree(node.child);
+    case HOCComponent: // 9
+        return childrenToTree(node.child);
     case HostPortal: { // 4
       const {
         stateNode: { containerInfo },


### PR DESCRIPTION
Hi!
I write several tests for my component and it's work fine, but when I wrapped my component with some HOC that create function like this:

```
function Foo(props) {
                var _this = _super.call(this, props) || this;
                _this.action = _this.action.bind(_this);
                _this.nodeParams = __assign({}, nodeParams, props.logNode, { events: __assign({}, nodeParams.events, (props.logNode && props.logNode.events)) });
                return _this;
}
```

I faced with error: `Enzyme Internal Error: unknown node with tag 9`.

I add code for this case to `enzyme-adapter-react-16.2` because I have `"enzyme-adapter-react-16": "1.2.0",` in my `package.json` file.

Not sure about that I need to add similar changes for other versions.

1. Can you approve my changes?
2. Can you help me with understanding about other adapter versions?
3. How else I can help? What kind of information I need to provide additionally?

Thanks :) 