### PR TITLE
[Docs] Update ShallowWrapper/instance wording to account for hooks

### DIFF
--- a/docs/api/ReactWrapper/instance.md
+++ b/docs/api/ReactWrapper/instance.md
@@ -2,56 +2,57 @@
 
 Returns the single-node wrapper's node's underlying class instance; `this` in its methods. It must be a single-node wrapper.
 
-NOTE: With React `16` and above, `instance()` returns `null` for stateless functional components.
-
+NOTE: can only be called on a wrapper instance that is also the root instance. With React `16` and above, `instance()` returns `null` for functional components, regardless of [hooks](https://reactjs.org/docs/hooks-intro.html) usage.
 
 #### Returns
 
 `ReactComponent|DOMComponent`: The retrieved instance.
 
-
 #### Example
 
 <!-- eslint react/prop-types: 0, react/prefer-stateless-function: 0 -->
+
 ```jsx
-function Stateless() {
-  return <div>Stateless</div>;
+function SFC() {
+  return <div>MyFunction</div>;
 }
 
 class Stateful extends React.Component {
   render() {
-    return <div>Stateful</div>;
+    return <div>MyClass</div>;
   }
 }
 ```
 
 #### React 16.x
+
 ```jsx
-test('mount wrapper instance should be null', () => {
-  const wrapper = mount(<Stateless />);
+test('wrapper instance is null', () => {
+  const wrapper = mount(<SFC />);
   const instance = wrapper.instance();
 
   expect(instance).to.equal(null);
 });
 
-test('mount wrapper instance should not be null', () => {
+test('wrapper instance is not null', () => {
   const wrapper = mount(<Stateful />);
   const instance = wrapper.instance();
 
-  expect(instance).to.be.instanceOf(Stateful);
+  expect(instance).to.be.instanceOf(MyCStatefullass);
 });
 ```
 
 #### React 15.x
+
 ```jsx
-test('mount wrapper instance should not be null', () => {
-  const wrapper = mount(<Stateless />);
+test('wrapper instance is not null', () => {
+  const wrapper = mount(<SFC />);
   const instance = wrapper.instance();
 
-  expect(instance).to.be.instanceOf(Stateless);
+  expect(instance).to.be.instanceOf(SFC);
 });
 
-test('mount wrapper instance should not be null', () => {
+test('wrapper instance is not null', () => {
   const wrapper = mount(<Stateful />);
   const instance = wrapper.instance();
 

--- a/docs/api/ShallowWrapper/instance.md
+++ b/docs/api/ShallowWrapper/instance.md
@@ -1,57 +1,58 @@
 # `.instance() => ReactComponent`
 
-Returns the single-node wrapper's node's underlying class instance; `this` in its methods.
+Returns the single-node wrapper's node's underlying class instance; `this` in its methods. It must be a single-node wrapper.
 
-NOTE: can only be called on a wrapper instance that is also the root instance. With React `16` and above, `instance()` returns `null` for stateless functional components.
-
+NOTE: can only be called on a wrapper instance that is also the root instance. With React `16` and above, `instance()` returns `null` for functional components, regardless of [hooks](https://reactjs.org/docs/hooks-intro.html) usage.
 
 #### Returns
 
 `ReactComponent|DOMComponent`: The retrieved instance.
 
-
 #### Example
 
 <!-- eslint react/prop-types: 0, react/prefer-stateless-function: 0 -->
+
 ```jsx
-function Stateless() {
-  return <div>Stateless</div>;
+function SFC() {
+  return <div>MyFunction</div>;
 }
 
 class Stateful extends React.Component {
   render() {
-    return <div>Stateful</div>;
+    return <div>MyClass</div>;
   }
 }
 ```
 
 #### React 16.x
+
 ```jsx
-test('shallow wrapper instance should be null', () => {
-  const wrapper = shallow(<Stateless />);
+test('wrapper instance is null', () => {
+  const wrapper = shallow(<SFC />);
   const instance = wrapper.instance();
 
   expect(instance).to.equal(null);
 });
 
-test('shallow wrapper instance should not be null', () => {
+test('wrapper instance is not null', () => {
   const wrapper = shallow(<Stateful />);
   const instance = wrapper.instance();
 
-  expect(instance).to.be.instanceOf(Stateful);
+  expect(instance).to.be.instanceOf(MyCStatefullass);
 });
 ```
 
 #### React 15.x
+
 ```jsx
-test('shallow wrapper instance should not be null', () => {
-  const wrapper = shallow(<Stateless />);
+test('wrapper instance is not null', () => {
+  const wrapper = shallow(<SFC />);
   const instance = wrapper.instance();
 
-  expect(instance).to.be.instanceOf(Stateless);
+  expect(instance).to.be.instanceOf(SFC);
 });
 
-test('shallow wrapper instance should not be null', () => {
+test('wrapper instance is not null', () => {
   const wrapper = shallow(<Stateful />);
   const instance = wrapper.instance();
 


### PR DESCRIPTION
# Description

This updates the wording on https://airbnb.io/enzyme/docs/api/ShallowWrapper/instance.html# to account for React Hooks.

