### PR TITLE
Remove always true if statement

### DIFF
--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -641,29 +641,27 @@ class ReactSixteenAdapter extends EnzymeAdapter {
             ));
           }
 
-          if (isStateful) {
-            // fix react bug; see implementation of `getEmptyStateValue`
-            const emptyStateValue = getEmptyStateValue();
-            if (emptyStateValue) {
-              Object.defineProperty(Component.prototype, 'state', {
-                configurable: true,
-                enumerable: true,
-                get() {
-                  return null;
-                },
-                set(value) {
-                  if (value !== emptyStateValue) {
-                    Object.defineProperty(this, 'state', {
-                      configurable: true,
-                      enumerable: true,
-                      value,
-                      writable: true,
-                    });
-                  }
-                  return true;
-                },
-              });
-            }
+          // fix react bug; see implementation of `getEmptyStateValue`
+          const emptyStateValue = getEmptyStateValue();
+          if (emptyStateValue) {
+            Object.defineProperty(Component.prototype, 'state', {
+              configurable: true,
+              enumerable: true,
+              get() {
+                return null;
+              },
+              set(value) {
+                if (value !== emptyStateValue) {
+                  Object.defineProperty(this, 'state', {
+                    configurable: true,
+                    enumerable: true,
+                    value,
+                    writable: true,
+                  });
+                }
+                return true;
+              },
+            });
           }
           return withSetStateAllowed(() => renderer.render(renderedEl, context));
         }

--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -641,27 +641,29 @@ class ReactSixteenAdapter extends EnzymeAdapter {
             ));
           }
 
-          // fix react bug; see implementation of `getEmptyStateValue`
-          const emptyStateValue = getEmptyStateValue();
-          if (emptyStateValue) {
-            Object.defineProperty(Component.prototype, 'state', {
-              configurable: true,
-              enumerable: true,
-              get() {
-                return null;
-              },
-              set(value) {
-                if (value !== emptyStateValue) {
-                  Object.defineProperty(this, 'state', {
-                    configurable: true,
-                    enumerable: true,
-                    value,
-                    writable: true,
-                  });
-                }
-                return true;
-              },
-            });
+          if (isStateful(Component)) {
+            // fix react bug; see implementation of `getEmptyStateValue`
+            const emptyStateValue = getEmptyStateValue();
+            if (emptyStateValue) {
+              Object.defineProperty(Component.prototype, 'state', {
+                configurable: true,
+                enumerable: true,
+                get() {
+                  return null;
+                },
+                set(value) {
+                  if (value !== emptyStateValue) {
+                    Object.defineProperty(this, 'state', {
+                      configurable: true,
+                      enumerable: true,
+                      value,
+                      writable: true,
+                    });
+                  }
+                  return true;
+                },
+              });
+            }
           }
           return withSetStateAllowed(() => renderer.render(renderedEl, context));
         }


### PR DESCRIPTION
Since `isStateful` is a function, it will always be truthy, this PR simplifies an if-statement related to it.