### PR TITLE
Fix suspense fallback is invalid

### DIFF
--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -1765,7 +1765,7 @@ describe('shallow', () => {
     });
 
     it('finds LazyComponent when render component wrapping lazy component', () => {
-      const LazyComponent = lazy(fakeDynamicImport(DynamicComponent));
+      const LazyComponent = lazy(() => fakeDynamicImport(DynamicComponent));
       const SuspenseComponent = () => (
         <Suspense fallback={<Fallback />}>
           <LazyComponent />
@@ -1780,7 +1780,7 @@ describe('shallow', () => {
     });
 
     it('returns suspense and lazy component string when debug() is called', () => {
-      const LazyComponent = lazy(fakeDynamicImport(DynamicComponent));
+      const LazyComponent = lazy(() => fakeDynamicImport(DynamicComponent));
       const SuspenseComponent = () => (
         <Suspense fallback={<Fallback />}>
           <LazyComponent />
@@ -1795,7 +1795,7 @@ describe('shallow', () => {
     });
 
     it('renders lazy component when render Suspense without option', () => {
-      const LazyComponent = lazy(fakeDynamicImport(DynamicComponent));
+      const LazyComponent = lazy(() => fakeDynamicImport(DynamicComponent));
 
       const wrapper = shallow((
         <Suspense fallback={<Fallback />}>
@@ -1808,7 +1808,7 @@ describe('shallow', () => {
     });
 
     it('returns lazy component string when debug() is called', () => {
-      const LazyComponent = lazy(fakeDynamicImport(DynamicComponent));
+      const LazyComponent = lazy(() => fakeDynamicImport(DynamicComponent));
 
       const wrapper = shallow((
         <Suspense fallback={<Fallback />}>
@@ -1820,7 +1820,7 @@ describe('shallow', () => {
     });
 
     it('replaces LazyComponent with Fallback when render Suspense if options.suspenseFallback=true', () => {
-      const LazyComponent = lazy(fakeDynamicImport(DynamicComponent));
+      const LazyComponent = lazy(() => fakeDynamicImport(DynamicComponent));
 
       const wrapper = shallow((
         <Suspense fallback={<Fallback />}>
@@ -1833,7 +1833,7 @@ describe('shallow', () => {
     });
 
     it('returns fallback component string when debug() is called if options.suspenseFallback=true', () => {
-      const LazyComponent = lazy(fakeDynamicImport(DynamicComponent));
+      const LazyComponent = lazy(() => fakeDynamicImport(DynamicComponent));
 
       const wrapper = shallow((
         <Suspense fallback={<Fallback />}>
@@ -1845,7 +1845,7 @@ describe('shallow', () => {
     });
 
     it('throws if options.suspenseFallback is not boolean or undefined', () => {
-      const LazyComponent = lazy(fakeDynamicImport(DynamicComponent));
+      const LazyComponent = lazy(() => fakeDynamicImport(DynamicComponent));
       const SuspenseComponent = () => (
         <Suspense fallback={<Fallback />}>
           <LazyComponent />
@@ -1855,7 +1855,7 @@ describe('shallow', () => {
     });
 
     it('finds fallback after dive into functional component wrapping Suspense', () => {
-      const LazyComponent = lazy(fakeDynamicImport(DynamicComponent));
+      const LazyComponent = lazy(() => fakeDynamicImport(DynamicComponent));
       const SuspenseComponent = () => (
         <Suspense fallback={<Fallback />}>
           <LazyComponent />
@@ -1870,7 +1870,7 @@ describe('shallow', () => {
     });
 
     it('replaces nested LazyComponent with Fallback when render Suspense with options.suspenseFallback=true', () => {
-      const LazyComponent = lazy(fakeDynamicImport(DynamicComponent));
+      const LazyComponent = lazy(() => fakeDynamicImport(DynamicComponent));
 
       const wrapper = shallow((
         <Suspense fallback={<Fallback />}>
@@ -1890,7 +1890,8 @@ describe('shallow', () => {
     });
 
     it('does not replace LazyComponent with Fallback when render Suspense if options.suspenseFallback = false', () => {
-      const LazyComponent = lazy(fakeDynamicImport(DynamicComponent));
+      const LazyComponent = lazy(() => fakeDynamicImport(DynamicComponent));
+
 
       const wrapper = shallow((
         <Suspense fallback={<Fallback />}>
@@ -1903,7 +1904,7 @@ describe('shallow', () => {
     });
 
     it('does not replace nested LazyComponent with Fallback when render Suspense if option.suspenseFallback = false', () => {
-      const LazyComponent = lazy(fakeDynamicImport(DynamicComponent));
+      const LazyComponent = lazy(() => fakeDynamicImport(DynamicComponent));
 
       const wrapper = shallow((
         <Suspense fallback={<Fallback />}>
@@ -1923,7 +1924,7 @@ describe('shallow', () => {
     });
 
     it('throws when rendering lazy component', () => {
-      const LazyComponent = lazy(fakeDynamicImport(DynamicComponent));
+      const LazyComponent = lazy(() => fakeDynamicImport(DynamicComponent));
       expect(() => shallow(<LazyComponent />)).to.throw();
     });
   });

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -1816,7 +1816,9 @@ describe('shallow', () => {
         </Suspense>
       ));
 
-      expect(wrapper.debug()).to.equal('<lazy />');
+      expect(wrapper.debug()).to.equal(`<Suspense fallback={{...}}>
+  <lazy />
+</Suspense>`);
     });
 
     it('replaces LazyComponent with Fallback when render Suspense if options.suspenseFallback=true', () => {
@@ -1841,7 +1843,9 @@ describe('shallow', () => {
         </Suspense>
       ), { suspenseFallback: true });
 
-      expect(wrapper.debug()).to.equal('<Fallback />');
+      expect(wrapper.debug()).to.equal(`<Suspense fallback={{...}}>
+  <Fallback />
+</Suspense>`);
     });
 
     it('throws if options.suspenseFallback is not boolean or undefined', () => {


### PR DESCRIPTION
Resolved https://github.com/airbnb/enzyme/issues/2200

I updated `enzyme-adapter-react-16` to fix issue suspense fallback is invalid. I handled to always wrap `React.Suspense` component outside of `React.Lazy` and `React.Fallback` components in any case.

I passed all tests in master branch and local test by below code:
```js
test('renders suspenseFallback=true', () => {
  const el = <ComponentWrapper />;
  const wrapper = shallow(el, { suspenseFallback: true });
  expect(wrapper.find(Fallback).length).toEqual(1);
  expect(wrapper.find(LazyComponent).length).toEqual(0);
});

test('renders suspenseFallback=false', () => {
  const el = <ComponentWrapper />;
  const wrapper = shallow(el, { suspenseFallback: false });
  expect(wrapper.find(Fallback).length).toEqual(0);
  expect(wrapper.find(LazyComponent).length).toEqual(1);
});
```
Code cloned from issue to reproduce, it's failed in master branch and passed in this branch.

Note: Lazy component will always display as `<lazy />` in debug and If you want to expect this component, should be use `.find(Component)` instead of `.find('ComponentName')`.

Thanks for review!