### PR TITLE
[Tests] Add tests for rendering <video muted /> without using console.error

### DIFF
--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -1927,4 +1927,12 @@ describeWithDOM('mount', () => {
       expect(divProps.onClick).to.be.a('function');
     });
   });
+
+  describe('console', () => {
+    it('does not call console.warn when rendering <video muted />', () => {
+      const spy = sinon.spy(console, 'error');
+      mount(<video muted />);
+      expect(spy.args).to.deep.equal([]);
+    });
+  });
 });

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -2585,4 +2585,12 @@ describe('shallow', () => {
       expect(divProps.onClick).to.be.a('function');
     });
   });
+
+  describe('console', () => {
+    it('does not call console.warn when rendering <video muted />', () => {
+      const spy = sinon.spy(console, 'error');
+      shallow(<video muted />);
+      expect(spy.args).to.deep.equal([]);
+    });
+  });
 });


### PR DESCRIPTION
For issue #2326

This PR adds two tests (of which the one in `enzyme-test-suite/test/ReactWrapper-spec.jsx` is failing) per instructions from @ljharb. 