### PR TITLE
README: Fix adapter package compatibility table

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ React:
 | `enzyme-adapter-react-16` | `^16.4.0-0` |
 | `enzyme-adapter-react-16.3` | `~16.3.0-0` |
 | `enzyme-adapter-react-16.2` | `~16.2` |
-| `enzyme-adapter-react-16.1` | `~16.0.0-0 \|\| ~16.1` |
+| `enzyme-adapter-react-16.1` | <code>~16.0.0-0 &#124;&#124; ~16.1</code> |
 | `enzyme-adapter-react-15` | `^15.5.0` |
 | `enzyme-adapter-react-15.4` | `15.0.0-0 - 15.4.x` |
 | `enzyme-adapter-react-14` | `^0.14.0` |


### PR DESCRIPTION
Gitbook does not seem to support escaping pipe characters inside of a backtick code block, instead breaking the table formatting. This can be resolved by using HTML escapes and the `<code>` tag.

(Both render correctly in Github itself, which is the other place the README is viewed.)

I've tested this locally by running `yarn run docs:watch`, with the following results.

### Before
<img width="874" alt="Screenshot 2020-06-10 11 31 24" src="https://user-images.githubusercontent.com/2506770/84227194-ee59ab80-ab0d-11ea-92bc-be82b91f1dc5.png">

### After 
<img width="797" alt="Screenshot 2020-06-10 11 28 47" src="https://user-images.githubusercontent.com/2506770/84227136-d124dd00-ab0d-11ea-8b72-2765ad0f4b05.png">
