### PR TITLE
Fix: setContext doesn't trigger componentWillReceiveProps 

### DIFF
--- a/packages/enzyme-adapter-react-14/package.json
+++ b/packages/enzyme-adapter-react-14/package.json
@@ -39,6 +39,7 @@
   "license": "MIT",
   "dependencies": {
     "enzyme-adapter-utils": "^1.14.0",
+    "enzyme-shallow-equal": "^1.0.4",
     "object.assign": "^4.1.0",
     "object.values": "^1.1.1",
     "prop-types": "^15.7.2",

--- a/packages/enzyme-adapter-react-16.1/package.json
+++ b/packages/enzyme-adapter-react-16.1/package.json
@@ -39,6 +39,7 @@
   "license": "MIT",
   "dependencies": {
     "enzyme-adapter-utils": "^1.14.0",
+    "enzyme-shallow-equal": "^1.0.4",
     "object.assign": "^4.1.0",
     "prop-types": "^15.7.2",
     "react-is": "^16.13.1",

--- a/packages/enzyme-adapter-react-16.1/src/ReactSixteenOneAdapter.js
+++ b/packages/enzyme-adapter-react-16.1/src/ReactSixteenOneAdapter.js
@@ -16,6 +16,7 @@ import {
   Portal,
 } from 'react-is';
 import { EnzymeAdapter } from 'enzyme';
+import shallowEqual from 'enzyme-shallow-equal';
 import {
   displayNameOfNode,
   elementToTree as utilElementToTree,
@@ -36,6 +37,7 @@ import {
   getNodeFromRootFinder,
   wrapWithWrappingComponent,
   getWrappingComponentMountRenderer,
+  spyMethod,
 } from 'enzyme-adapter-utils';
 import { findCurrentFiberUsingSlowPath } from 'react-reconciler/reflection';
 
@@ -373,6 +375,29 @@ class ReactSixteenOneAdapter extends EnzymeAdapter {
             return withSetStateAllowed(() => renderer.render({ ...el, type: wrappedEl }, context));
           }
           if (isStateful) {
+            if (
+              renderer._instance
+              && el.props === renderer._instance.props
+              && !shallowEqual(context, renderer._instance.context)
+            ) {
+              const { restore } = spyMethod(
+                renderer,
+                '_updateClassComponent',
+                (originalMethod) => function _updateClassComponent(...args) {
+                  const { props } = renderer._instance;
+                  const clonedProps = { ...props };
+                  renderer._instance.props = clonedProps;
+
+                  const result = originalMethod.apply(renderer, args);
+
+                  renderer._instance.props = props;
+                  restore();
+
+                  return result;
+                },
+              );
+            }
+
             // fix react bug; see implementation of `getEmptyStateValue`
             const emptyStateValue = getEmptyStateValue();
             if (emptyStateValue) {

--- a/packages/enzyme-adapter-react-16.2/package.json
+++ b/packages/enzyme-adapter-react-16.2/package.json
@@ -39,6 +39,7 @@
   "license": "MIT",
   "dependencies": {
     "enzyme-adapter-utils": "^1.14.0",
+    "enzyme-shallow-equal": "^1.0.4",
     "object.assign": "^4.1.0",
     "object.values": "^1.1.1",
     "prop-types": "^15.7.2",

--- a/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
+++ b/packages/enzyme-adapter-react-16.2/src/ReactSixteenTwoAdapter.js
@@ -17,6 +17,7 @@ import {
 } from 'react-is';
 import { EnzymeAdapter } from 'enzyme';
 import { typeOfNode } from 'enzyme/build/Utils';
+import shallowEqual from 'enzyme-shallow-equal';
 import {
   displayNameOfNode,
   elementToTree as utilElementToTree,
@@ -37,6 +38,7 @@ import {
   getNodeFromRootFinder,
   wrapWithWrappingComponent,
   getWrappingComponentMountRenderer,
+  spyMethod,
 } from 'enzyme-adapter-utils';
 import { findCurrentFiberUsingSlowPath } from 'react-reconciler/reflection';
 
@@ -375,6 +377,29 @@ class ReactSixteenTwoAdapter extends EnzymeAdapter {
             return withSetStateAllowed(() => renderer.render({ ...el, type: wrappedEl }, context));
           }
           if (isStateful) {
+            if (
+              renderer._instance
+              && el.props === renderer._instance.props
+              && !shallowEqual(context, renderer._instance.context)
+            ) {
+              const { restore } = spyMethod(
+                renderer,
+                '_updateClassComponent',
+                (originalMethod) => function _updateClassComponent(...args) {
+                  const { props } = renderer._instance;
+                  const clonedProps = { ...props };
+                  renderer._instance.props = clonedProps;
+
+                  const result = originalMethod.apply(renderer, args);
+
+                  renderer._instance.props = props;
+                  restore();
+
+                  return result;
+                },
+              );
+            }
+
             // fix react bug; see implementation of `getEmptyStateValue`
             const emptyStateValue = getEmptyStateValue();
             if (emptyStateValue) {

--- a/packages/enzyme-adapter-react-16.3/package.json
+++ b/packages/enzyme-adapter-react-16.3/package.json
@@ -39,6 +39,7 @@
   "license": "MIT",
   "dependencies": {
     "enzyme-adapter-utils": "^1.14.0",
+    "enzyme-shallow-equal": "^1.0.4",
     "object.assign": "^4.1.0",
     "object.values": "^1.1.1",
     "prop-types": "^15.7.2",

--- a/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ReactWrapper-spec.jsx
@@ -122,7 +122,6 @@ describeWithDOM('mount', () => {
         expect(document.createElement('div')).to.be.instanceOf(HTMLElement);
 
         const [[firstArg]] = spy.args;
-        console.log(firstArg);
         expect(firstArg).to.be.instanceOf(HTMLElement);
       });
 

--- a/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
+++ b/packages/enzyme-test-suite/test/ShallowWrapper-spec.jsx
@@ -2087,6 +2087,10 @@ describe('shallow', () => {
           }
         }
 
+        Foo.contextTypes = {
+          foo: PropTypes.string,
+        };
+
         const options = {
           disableLifecycleMethods: true,
           context: {
@@ -2122,7 +2126,7 @@ describe('shallow', () => {
           ]);
         });
 
-        describeIf(is('0.13 || 15 || > 16'), 'setContext', () => {
+        describe('setContext', () => {
           it('calls expected methods when receiving new context', () => {
             const wrapper = shallow(<Foo />, options);
             expect(spy.args).to.deep.equal([
@@ -2130,43 +2134,11 @@ describe('shallow', () => {
               ['render'],
             ]);
             spy.resetHistory();
-            wrapper.setContext({ foo: 'foo' });
+
+            wrapper.setContext({ foo: 'bar' });
+
             expect(spy.args).to.deep.equal([
               ['componentWillReceiveProps'],
-              ['shouldComponentUpdate'],
-              ['componentWillUpdate'],
-              ['render'],
-            ]);
-          });
-        });
-
-        describeIf(is('16'), 'setContext', () => {
-          it('calls expected methods when receiving new context', () => {
-            const wrapper = shallow(<Foo />, options);
-            expect(spy.args).to.deep.equal([
-              ['componentWillMount'],
-              ['render'],
-            ]);
-            spy.resetHistory();
-            wrapper.setContext({ foo: 'foo' });
-            expect(spy.args).to.deep.equal([
-              ['shouldComponentUpdate'],
-              ['componentWillUpdate'],
-              ['render'],
-            ]);
-          });
-        });
-
-        describeIf(is('0.14'), 'setContext', () => {
-          it('calls expected methods when receiving new context', () => {
-            const wrapper = shallow(<Foo />, options);
-            expect(spy.args).to.deep.equal([
-              ['componentWillMount'],
-              ['render'],
-            ]);
-            spy.resetHistory();
-            wrapper.setContext({ foo: 'foo' });
-            expect(spy.args).to.deep.equal([
               ['shouldComponentUpdate'],
               ['componentWillUpdate'],
               ['render'],


### PR DESCRIPTION
Fixes #2258

Below are two code sandboxes that show the bug exists, i added enzyme to the sandbox when you run the tests sandbox 2 doesn't call the method while sandbox 1 does.
-  [Sandbox #1](https://codesandbox.io/s/distracted-sun-8vqh9) enzyme 3.3.0, react 16.14.0
-  [Sandbox #2](https://codesandbox.io/s/lucid-wilbur-wkotf) enzyme 3.4.0, react 16.0.0