### PR TITLE
[Fix] Ensure recursive calls to displayNameOfNode uses the adapter's version of the method

### DIFF
--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -863,6 +863,7 @@ class ReactSixteenAdapter extends EnzymeAdapter {
   displayNameOfNode(node) {
     if (!node) return null;
     const { type, $$typeof } = node;
+    const adapter = this;
 
     const nodeType = type || $$typeof;
 
@@ -886,13 +887,13 @@ class ReactSixteenAdapter extends EnzymeAdapter {
       case ContextProvider || NaN: return 'ContextProvider';
       case Memo || NaN: {
         const nodeName = displayNameOfNode(node);
-        return typeof nodeName === 'string' ? nodeName : `Memo(${displayNameOfNode(type)})`;
+        return typeof nodeName === 'string' ? nodeName : `Memo(${adapter.displayNameOfNode(type)})`;
       }
       case ForwardRef || NaN: {
         if (type.displayName) {
           return type.displayName;
         }
-        const name = displayNameOfNode({ type: type.render });
+        const name = adapter.displayNameOfNode({ type: type.render });
         return name ? `ForwardRef(${name})` : 'ForwardRef';
       }
       case Lazy || NaN: {

--- a/packages/enzyme-test-suite/test/Utils-spec.jsx
+++ b/packages/enzyme-test-suite/test/Utils-spec.jsx
@@ -568,6 +568,41 @@ describe('Utils', () => {
         expect(displayNameOfNode(<div />)).to.equal('div');
       });
     });
+
+    describeIf(is('>= 16.6'), 'given an inner displayName in Memo', () => {
+      it('returns the displayName', () => {
+        const adapter = getAdapter();
+        const Foo = () => <div />;
+        Foo.displayName = 'CustomWrapper';
+
+        const MemoFoo = React.memo(Foo);
+
+        expect(adapter.displayNameOfNode(<MemoFoo />)).to.equal('Memo(CustomWrapper)');
+      });
+    });
+
+    describeIf(is('>= 16.6'), 'given an inner displayName in forwardedRef', () => {
+      it('returns the displayName', () => {
+        const adapter = getAdapter();
+        const Foo = () => <div />;
+        Foo.displayName = 'CustomWrapper';
+
+        const ForwardedFoo = React.forwardRef(Foo);
+
+        expect(adapter.displayNameOfNode(<ForwardedFoo />)).to.equal('ForwardRef(CustomWrapper)');
+      });
+    });
+
+    describeIf(is('>= 16.6'), 'given an inner displayName wrapped in Memo and forwardRef', () => {
+      it('returns the displayName', () => {
+        const adapter = getAdapter();
+        const Foo = () => <div />;
+        Foo.displayName = 'CustomWrapper';
+
+        const MemoForwardFoo = React.memo(React.forwardRef(Foo));
+        expect(adapter.displayNameOfNode(<MemoForwardFoo />)).to.equal('Memo(ForwardRef(CustomWrapper))');
+      });
+    });
   });
 
   describe('childrenToSimplifiedArray', () => {


### PR DESCRIPTION
Fixes #2481

This is my first contribution to enzyme so happy to update/modify this PR as needed.