### PR TITLE
Fix `simulateError()` on Memo component

### DIFF
--- a/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
+++ b/packages/enzyme-adapter-react-16/src/ReactSixteenAdapter.js
@@ -527,7 +527,7 @@ class ReactSixteenAdapter extends EnzymeAdapter {
           rootNode,
           nodeHierarchy,
           nodeTypeFromType,
-          adapter.displayNameOfNode,
+          adapter.displayNameOfNode.bind(adapter),
           is166 ? catchingType : undefined,
         );
       },
@@ -787,7 +787,7 @@ class ReactSixteenAdapter extends EnzymeAdapter {
           cachedNode,
           nodeHierarchy.concat(cachedNode),
           nodeTypeFromType,
-          adapter.displayNameOfNode,
+          adapter.displayNameOfNode.bind(adapter),
           is166 ? cachedNode.type : undefined,
         );
       },


### PR DESCRIPTION
We are seeing `TypeError: Cannot read property 'displayNameOfNode' of undefined` errors and I believe I tracked it down to a regression introduced in https://github.com/enzymejs/enzyme/pull/2482. The `displayNameOfNode()` method  now references `this` but with `simulateError()` it ends up being called unbound. My fix is to just always bind `adapter.displayNameOfNode` so `this` is always `adapter`.

Thanks!