### PR TITLE
[Docs] `mount`/`shallow`: `update`: Bring the docs up to date with the implementation

### DIFF
--- a/docs/api/ReactWrapper/update.md
+++ b/docs/api/ReactWrapper/update.md
@@ -3,8 +3,10 @@
 Syncs the enzyme component tree snapshot with the react component tree. Useful to run before checking the render output if something external
 may be updating the state of the component somewhere.
 
-NOTE: can only be called on a wrapper instance that is also the root instance.
-NOTE: only update the Enzyme's representation of rendered tree.
+NOTE: no matter what instance this is called on, it will always update the root.
+
+NOTE: only updates Enzyme's representation of rendered tree.
+
 NOTE: this does not force a re-render. Use `wrapper.setProps({})` to force a re-render.
 
 

--- a/docs/api/ShallowWrapper/update.md
+++ b/docs/api/ShallowWrapper/update.md
@@ -3,8 +3,10 @@
 Syncs the enzyme component tree snapshot with the react component tree. Useful to run before checking the render output if something external
 may be updating the state of the component somewhere.
 
-NOTE: can only be called on a wrapper instance that is also the root instance.
-NOTE: only update the Enzyme's representation of rendered tree.
+NOTE: no matter what instance this is called on, it will always update the root.
+
+NOTE: only updates Enzyme's representation of rendered tree.
+
 NOTE: this does not force a re-render. Use `wrapper.setProps({})` to force a re-render.
 
 


### PR DESCRIPTION
I've noticed that the docs for `update` still say "should only be called on root", but this hasn't been the case for three years now (changed in https://github.com/enzymejs/enzyme/pull/1802).

**Side note 1**: the example in this file doesn't actually require an `update()` call. The text of the button does update just fine by itself. I played with it for some time just now, and couldn't come up with an example where an `update` call would be required. Could there have been some change recently that made `update` unnecessary?

**Side note 2**: the docs currently published on https://enzymejs.github.io/ seem outdated compared to the source code. I'm not sure what the publishing procedure would be, but I'm pretty sure I can't do it myself, because I don't have proper access.