### PR TITLE
style(mount.md): fix typo in function definition

### DIFF
--- a/docs/api/mount.md
+++ b/docs/api/mount.md
@@ -40,7 +40,7 @@ describe('<Foo />', () => {
 });
 ```
 
-## `mount(node[, options]) => ReactWrapper`
+## `mount(node,[options]) => ReactWrapper`
 
 #### Arguments
 


### PR DESCRIPTION
Fixes a minor typo in the doc